### PR TITLE
Update for new asset URLS in recent argo releases

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -14,6 +14,6 @@ jobs:
       - name: asdf_plugin_test
         uses: asdf-vm/actions/plugin-test@v1.0.0
         with:
-          command: "argo version"
+          command: "argo -h"
         env:
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }} # automatically provided

--- a/bin/install
+++ b/bin/install
@@ -4,13 +4,16 @@ set -e
 set -o pipefail
 
 install_argo() {
-  local install_type=$1
-  local version=$2
-  local install_path=$3
-  local platform="$(uname | tr '[:upper:]' '[:lower:]')-amd64"
-  local bin_install_path="$install_path/bin"
-  local binary_path="$bin_install_path/argo"
-  local download_url=$(get_download_url $version $platform)
+  local install_type version install_path platform bin_install_path binary_path download_url
+
+  # shellcheck disable=SC2034
+  install_type="$1"
+  version="$2"
+  install_path="$3"
+  platform="$(uname | tr '[:upper:]' '[:lower:]')-amd64"
+  bin_install_path="$install_path/bin"
+  binary_path="$bin_install_path/argo"
+  download_url="$(get_download_url "$version" "$platform")"
 
   echo "Creating bin directory"
   mkdir -p "${bin_install_path}"
@@ -21,8 +24,10 @@ install_argo() {
 }
 
 download() {
-  local url="$1"
-  local output="$2"
+  local url output
+
+  url="$1"
+  output="$2"
 
   echo "Downloading argo from ${url} to ${output}"
 
@@ -39,10 +44,12 @@ get_filename() {
 }
 
 get_download_url() {
-  local version="$1"
-  local platform="$2"
-  local filename="$(get_filename $platform)"
+  local version platform filename
+
+  version="$1"
+  platform="$2"
+  filename="$(get_filename "$platform")"
   echo "https://github.com/argoproj/argo/releases/download/v${version}/${filename}"
 }
 
-install_argo $ASDF_INSTALL_TYPE $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH
+install_argo "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"

--- a/bin/install
+++ b/bin/install
@@ -15,11 +15,23 @@ install_argo() {
   echo "Creating bin directory"
   mkdir -p "${bin_install_path}"
 
-  echo "Downloading argo from ${download_url} to ${binary_path}"
-  curl -L "${download_url}" -o "${binary_path}"
+  # older releases of argo do not use gzipped assets
+  download "${download_url}.gz" "${binary_path}" || download "${download_url}" "${binary_path}"
   chmod +x "${binary_path}"
 }
 
+download() {
+  local url="$1"
+  local output="$2"
+
+  echo "Downloading argo from ${url} to ${output}"
+
+  if [[ "$url" =~ .gz$ ]]; then
+    curl -fL "${url}" | gunzip > "${output}"
+  else
+    curl -fL "${url}" -o "${output}"
+  fi
+}
 
 get_filename() {
   local platform="$1"

--- a/bin/list-all
+++ b/bin/list-all
@@ -12,5 +12,5 @@ function sort_versions() {
     LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
-versions=$(eval $cmd | grep -oE "tag_name\": *\".{1,15}\"," | sed 's/tag_name\": *\"v//;s/\",//' | sort_versions)
-echo $versions
+versions=$(eval "$cmd" | grep -oE "tag_name\": *\".{1,15}\"," | sed 's/tag_name\": *\"v//;s/\",//' | sort_versions)
+echo "$versions"


### PR DESCRIPTION
In recent releases of argo, they've started gzipping their release assets before uploading them. See, for example, this release https://github.com/argoproj/argo/releases/tag/v2.10.1.

This change tries to download from the gz urls and falls back on the non-gz urls if the assets aren't found. This assumes they'll continue to gzip assets and that people are mostly going to want newer releases of argo.

The second commit just makes this code compliant with [shellcheck](https://github.com/koalaman/shellcheck).

Let me know if you want me to make any changes. Thanks for maintaining this plugin!

