### PR TITLE
Fix argo github project URL

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -49,7 +49,7 @@ get_download_url() {
   version="$1"
   platform="$2"
   filename="$(get_filename "$platform")"
-  echo "https://github.com/argoproj/argo/releases/download/v${version}/${filename}"
+  echo "https://github.com/argoproj/argo-workflows/releases/download/v${version}/${filename}"
 }
 
 install_argo "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-release_path=https://api.github.com/repos/argoproj/argo/releases
+release_path=https://api.github.com/repos/argoproj/argo-workflows/releases
 cmd="curl -s"
 if [ -n "$GITHUB_API_TOKEN" ]; then
   cmd="$cmd -H 'Authorization: token $GITHUB_API_TOKEN'"


### PR DESCRIPTION
The argo project got renamed to argo-workflows and thus the URL needs updating.
argo => argo-workflows